### PR TITLE
feat: extend built-it in hooks with the utilities

### DIFF
--- a/package/src/utils/add-virtual-import.ts
+++ b/package/src/utils/add-virtual-import.ts
@@ -7,7 +7,7 @@ const resolveVirtualModuleId = <T extends string>(id: T): `\0${T}` => {
 	return `\0${id}`;
 };
 
-const createVirtualModule = (name: string, content: string): Plugin => {
+export const createVirtualModule = (name: string, content: string): Plugin => {
 	const pluginName = `vite-plugin-${name}`;
 
 	return {


### PR DESCRIPTION
```diff
-import { addVitePlugin, defineIntegration } from "astro-integration-kit";
+import { defineIntegration } from "astro-integration-kit";
import { VitePWA } from 'vite-plugin-pwa'

export default defineIntegration({
    name: "my-integration",
    setup(options) {
        return {
-           "astro:config:setup": () => {
+           "astro:config:setup": ({ addVitePlugin }) => {
                addVitePlugin(VitePWA({ registerType: 'autoUpdate' }))
            }
        }
    }
})
```